### PR TITLE
Add printing deprecation message to generated package.json

### DIFF
--- a/src/azure/CodeGeneratorJsa.cs
+++ b/src/azure/CodeGeneratorJsa.cs
@@ -14,7 +14,7 @@ namespace AutoRest.NodeJS.Azure
 {
     public class CodeGeneratorJsa : CodeGeneratorJs
     {
-        private const string ClientRuntimePackage = "ms-rest-azure version 2.0.0";
+        private const string ClientRuntimePackage = "ms-rest-azure version 2.6.0";
 
         public override string UsageInstructions => $"The {ClientRuntimePackage} or higher npm package is required to execute the generated code.";
 

--- a/src/azure/Model/CodeModelJsa.cs
+++ b/src/azure/Model/CodeModelJsa.cs
@@ -13,7 +13,7 @@ using AutoRest.Core;
 
 namespace AutoRest.NodeJS.Azure.Model
 {
-    
+
     public class CodeModelJsa : CodeModelJs
     {
         public CodeModelJsa()
@@ -58,7 +58,7 @@ namespace AutoRest.NodeJS.Azure.Model
             {
                 List<string> predefinedOptionalParameters = new List<string>() { "apiVersion", "acceptLanguage", "longRunningOperationRetryTimeout", "generateClientRequestId", "rpRegistrationRetryTimeout" };
                 var optionalParameters = this.Properties.Where(
-                    p => (!p.IsRequired || p.IsRequired && !string.IsNullOrEmpty(p.DefaultValue)) 
+                    p => (!p.IsRequired || p.IsRequired && !string.IsNullOrEmpty(p.DefaultValue))
                     && !p.IsConstant && !predefinedOptionalParameters.Contains(p.Name));
                 return optionalParameters.Count() > 0;
             }

--- a/src/vanilla/CodeGeneratorJs.cs
+++ b/src/vanilla/CodeGeneratorJs.cs
@@ -17,7 +17,7 @@ namespace AutoRest.NodeJS
 {
     public class CodeGeneratorJs : CodeGenerator
     {
-        private const string ClientRuntimePackage = "ms-rest version 2.0.0";
+        private const string ClientRuntimePackage = "ms-rest version 2.4.0";
 
         public override string ImplementationFileExtension => ".js";
 

--- a/src/vanilla/Model/CodeModelJs.cs
+++ b/src/vanilla/Model/CodeModelJs.cs
@@ -94,7 +94,7 @@ namespace AutoRest.NodeJS.Model
         {
             return new[]
             {
-                "\"ms-rest\": \"^2.3.3\""
+                "\"ms-rest\": \"^2.4.0\""
             };
         }
 

--- a/src/vanilla/Templates/PackageJson.cshtml
+++ b/src/vanilla/Templates/PackageJson.cshtml
@@ -22,5 +22,8 @@
   },
   "bugs": {
     "url": "@(Model.BugsUrl)"
+  },
+ "scripts": {
+    "postinstall": "npm explore ms-rest -- npm run print-deprecation-message"
   }
 }

--- a/test/options/generatelicense-vanilla-false/Expected/AcceptanceTests/ParameterFlattening/package.json
+++ b/test/options/generatelicense-vanilla-false/Expected/AcceptanceTests/ParameterFlattening/package.json
@@ -4,7 +4,7 @@
   "description": "AutoRestParameterFlattening Library with typescript type definitions for node",
   "version": "1.0.0-preview",
   "dependencies": {
-    "ms-rest": "^2.3.3"
+    "ms-rest": "^2.4.0"
   },
   "keywords": [
     "node",
@@ -20,5 +20,8 @@
   },
   "bugs": {
     "url": "https://github.com/azure/azure-sdk-for-node/issues"
+  },
+ "scripts": {
+    "postinstall": "npm explore ms-rest -- npm run print-deprecation-message"
   }
 }

--- a/test/options/generatelicense-vanilla-true/Expected/AcceptanceTests/ParameterFlattening/package.json
+++ b/test/options/generatelicense-vanilla-true/Expected/AcceptanceTests/ParameterFlattening/package.json
@@ -4,7 +4,7 @@
   "description": "AutoRestParameterFlattening Library with typescript type definitions for node",
   "version": "1.0.0-preview",
   "dependencies": {
-    "ms-rest": "^2.3.3"
+    "ms-rest": "^2.4.0"
   },
   "keywords": [
     "node",
@@ -20,5 +20,8 @@
   },
   "bugs": {
     "url": "https://github.com/azure/azure-sdk-for-node/issues"
+  },
+ "scripts": {
+    "postinstall": "npm explore ms-rest -- npm run print-deprecation-message"
   }
 }

--- a/test/options/generatereadmemd-azure-true/Expected/AcceptanceTests/ParameterFlattening/package.json
+++ b/test/options/generatereadmemd-azure-true/Expected/AcceptanceTests/ParameterFlattening/package.json
@@ -4,7 +4,7 @@
   "description": "AutoRestParameterFlattening Library with typescript type definitions for node",
   "version": "1.0.0-preview",
   "dependencies": {
-    "ms-rest": "^2.3.3",
+    "ms-rest": "^2.4.0",
     "ms-rest-azure": "^2.5.5"
   },
   "keywords": [
@@ -21,5 +21,8 @@
   },
   "bugs": {
     "url": "https://github.com/azure/azure-sdk-for-node/issues"
+  },
+ "scripts": {
+    "postinstall": "npm explore ms-rest -- npm run print-deprecation-message"
   }
 }

--- a/test/options/generatereadmemd-vanilla-true/Expected/AcceptanceTests/ParameterFlattening/package.json
+++ b/test/options/generatereadmemd-vanilla-true/Expected/AcceptanceTests/ParameterFlattening/package.json
@@ -4,7 +4,7 @@
   "description": "AutoRestParameterFlattening Library with typescript type definitions for node",
   "version": "1.2.3",
   "dependencies": {
-    "ms-rest": "^2.3.3"
+    "ms-rest": "^2.4.0"
   },
   "keywords": [
     "node",
@@ -20,5 +20,8 @@
   },
   "bugs": {
     "url": "https://github.com/azure/azure-sdk-for-node/issues"
+  },
+ "scripts": {
+    "postinstall": "npm explore ms-rest -- npm run print-deprecation-message"
   }
 }

--- a/test/options/sourcecodefolderpath-azure-sources/Expected/AcceptanceTests/ParameterFlattening/package.json
+++ b/test/options/sourcecodefolderpath-azure-sources/Expected/AcceptanceTests/ParameterFlattening/package.json
@@ -4,7 +4,7 @@
   "description": "AutoRestParameterFlattening Library with typescript type definitions for node",
   "version": "1.0.0-preview",
   "dependencies": {
-    "ms-rest": "^2.3.3",
+    "ms-rest": "^2.4.0",
     "ms-rest-azure": "^2.5.5"
   },
   "keywords": [
@@ -21,5 +21,8 @@
   },
   "bugs": {
     "url": "https://github.com/azure/azure-sdk-for-node/issues"
+  },
+ "scripts": {
+    "postinstall": "npm explore ms-rest -- npm run print-deprecation-message"
   }
 }

--- a/test/options/sourcecodefolderpath-vanilla-sources/Expected/AcceptanceTests/ParameterFlattening/package.json
+++ b/test/options/sourcecodefolderpath-vanilla-sources/Expected/AcceptanceTests/ParameterFlattening/package.json
@@ -4,7 +4,7 @@
   "description": "AutoRestParameterFlattening Library with typescript type definitions for node",
   "version": "1.0.0-preview",
   "dependencies": {
-    "ms-rest": "^2.3.3"
+    "ms-rest": "^2.4.0"
   },
   "keywords": [
     "node",
@@ -20,5 +20,8 @@
   },
   "bugs": {
     "url": "https://github.com/azure/azure-sdk-for-node/issues"
+  },
+ "scripts": {
+    "postinstall": "npm explore ms-rest -- npm run print-deprecation-message"
   }
 }


### PR DESCRIPTION
We need to publish new ms-rest first and update it in the generated dependencies.

Readme file is done - e.g. https://www.npmjs.com/package/azure-arm-eventgrid 